### PR TITLE
Update raspi-peripheral dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Provides access to Soft PWM on the Raspberry Pi as part of the Raspi.js library suite",
   "main": "lib/index.js",
   "dependencies": {
-    "raspi-peripheral": "1.3.0",
+    "raspi-peripheral": "1.6.0",
     "pigpio": "^0.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Update `raspi-peripheral` to version 1.6.0 (add Raspberry Pi Zero and Raspberry Pi 3 Model B).
